### PR TITLE
fix(search): ES-3922 add bytes field type support for bunny

### DIFF
--- a/src/Bunny/Constants.php
+++ b/src/Bunny/Constants.php
@@ -251,4 +251,6 @@ final class Constants
 
     const FIELD_NULL = 0x56; // 'V'
 
+    const FIELD_BYTES = 0x78; // 'X'
+
 }

--- a/src/Bunny/Protocol/ProtocolReader.php
+++ b/src/Bunny/Protocol/ProtocolReader.php
@@ -262,6 +262,7 @@ class ProtocolReader
             case Constants::FIELD_SHORT_STRING:
                 return $buffer->consume($buffer->consumeUint8());
             case Constants::FIELD_LONG_STRING:
+            case Constants::FIELD_BYTES:
                 return $buffer->consume($buffer->consumeUint32());
             case Constants::FIELD_ARRAY:
                 return $this->consumeArray($buffer);


### PR DESCRIPTION
Adds support for bytes type that is causing errors in processing domain events.